### PR TITLE
Fix screenshot links

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,35 +47,35 @@ And then startup the server and view :)
 
 New Repository:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/new-repo.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/new-repo.jpg
 
 Repository Browsing:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/repo-dir.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/repo-dir.jpg
 
 File Viewing:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/repo-file.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/repo-file.jpg
 
 File Blame:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/repo-file-blame.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/repo-file-blame.jpg
 
 Commits:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/repo-commits.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/repo-commits.jpg
 
 Commit:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/repo-commit.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/repo-commit.jpg
 
 Hooks:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/repo-hooks.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/repo-hooks.jpg
 
 Multi-View:
 
-http://github.com/drcapulet/warehouse/raw/master/screens/screen-multi.jpg
+https://github.com/drcapulet/warehouse/raw/master/screens/screen-multi.jpg
 
 == Contributing
 


### PR DESCRIPTION
I happened by your project (which looks neat, BTW!), and saw that the links to the screenshots were broken, since GitHub went to https.  Here's a quick fix for that.
